### PR TITLE
WIP: fix initial_cluster_string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # UNRELEASED
+- BUG: Fix etcd initial_cluster_string 
 
 # 1.18.6 (17.07.2020)
 - [Kubernetes: 1.18.6](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.18.md#changelog-since-v1185)

--- a/recipes/etcd.rb
+++ b/recipes/etcd.rb
@@ -99,7 +99,7 @@ else
 
   etcd_service_manager_systemd 'etcd' do
     action :start
-    node_name k8s_ip
+    node_name etcd_ip
     default_service_name node['etcd']['default_service_name']
     advertise_client_urls "#{node['etcd']['proto']}://#{etcd_ip}:#{node['etcd']['client_port']}"
     cert_file node['etcd']['cert_file']

--- a/recipes/etcd.rb
+++ b/recipes/etcd.rb
@@ -8,7 +8,7 @@
 etcd_nodes = search(
   :node,
   "roles:#{node['etcd']['role']}"
-).map { |n| k8s_ip(n) }.sort
+).map { |n| etcd_ip(n) }.sort
 
 initial_cluster_string =
   etcd_nodes.map do |addr|

--- a/recipes/etcd.rb
+++ b/recipes/etcd.rb
@@ -53,6 +53,7 @@ end
     recursive true
     owner etcd_user
     group etcd_group
+    mode '0700'
   end
 end
 


### PR DESCRIPTION
This PR fix:
```
Jul 23 01:27:36 kube02-test etcd[20613]: advertise client URLs = https://10.0.0.3:2379
Jul 23 01:27:36 kube02-test etcd[20613]: --initial-cluster has 1.1.1.2=https://1.1.1.2:2380 but missing from --initial-advertise-peer-urls=https://10.0.0.3:2380 ("https://10.0.0.3:2380"(resolved from "https://10.0.0.3:2380") != "https://1.1.1.2:2380"(resolved from "https://1.1.1.2:2380"))
Jul 23 01:27:36 kube02-test systemd[1]: etcd.service: Main process exited, code=exited, status=1/FAILURE
```